### PR TITLE
AssetBundle ビルド時に前後処理を行えるようにする

### DIFF
--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2cc718a1ec2b74930aafaa0df63464f5
+folderAsset: yes
+timeCreated: 1507793051
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Scripts.meta
+++ b/Assets/Tests/Scripts.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ca3c53d7fa8314db9a17902bc881c875
+folderAsset: yes
+timeCreated: 1507793057
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Scripts/Editor.meta
+++ b/Assets/Tests/Scripts/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5c2fb0eadbe184436910188a56ab38bf
+folderAsset: yes
+timeCreated: 1507793066
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Scripts/Editor/SimpleBuild.meta
+++ b/Assets/Tests/Scripts/Editor/SimpleBuild.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c2688d0e148e94e44b1311536084dcfd
+folderAsset: yes
+timeCreated: 1507793072
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Scripts/Editor/SimpleBuild/BuildAssetBundleTest.cs
+++ b/Assets/Tests/Scripts/Editor/SimpleBuild/BuildAssetBundleTest.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace SimpleBuild {
+
+    public class BuildAssetBundleTest {
+
+        [Test]
+        public void PreprocessBuildTest() {
+            MockProcessor.HasCalledOnPreprocess = false;
+            BuildAssetBundle.Run();
+            Assert.True(MockProcessor.HasCalledOnPreprocess);
+        }
+
+        [Test]
+        public void PostprocessBuildTest() {
+            MockProcessor.HasCalledOnPostprocess = false;
+            BuildAssetBundle.Run();
+            Assert.True(MockProcessor.HasCalledOnPostprocess);
+        }
+
+    }
+
+    internal class MockProcessor : IPreprocessBuildAssetBundle, IPostprocessBuildAssetBundle {
+
+        public static bool HasCalledOnPreprocess { get; set; }
+
+        public static bool HasCalledOnPostprocess { get; set; }
+
+        public void OnPreprocessBuildAssetBundle(string outputPath) {
+            HasCalledOnPreprocess = true;
+        }
+
+        public void OnPostprocessBuildAssetBundle(string outputPath) {
+            HasCalledOnPostprocess = true;
+        }
+
+    }
+
+}

--- a/Assets/Tests/Scripts/Editor/SimpleBuild/BuildAssetBundleTest.cs.meta
+++ b/Assets/Tests/Scripts/Editor/SimpleBuild/BuildAssetBundleTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6661ea29cfd4d4481a9435667ad731f8
+timeCreated: 1507793079
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -66,7 +66,7 @@ PlayerSettings:
   disableDepthAndStencilBuffers: 0
   defaultIsFullScreen: 1
   defaultIsNativeResolution: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.1.0p4
+m_EditorVersion: 2017.1.1p3


### PR DESCRIPTION
* Unity 2017.1.1p3 時点では AssetBundle ビルド時に IPreprocessBuild や IPostprocessBuild に相当する処理を行えない
* なので、 Reflection 使ったゴリゴリの処理を実装します
* テストも書いてます。