### PR TITLE
Pre/PostprocessBuildAssetBundle の呼び出し順制御を行う

### DIFF
--- a/Assets/Tests/Scripts/Editor/SimpleBuild/BuildAssetBundleTest.cs
+++ b/Assets/Tests/Scripts/Editor/SimpleBuild/BuildAssetBundleTest.cs
@@ -37,6 +37,8 @@ namespace SimpleBuild {
             HasCalledOnPostprocess = true;
         }
 
+        public int callbackOrder { get; private set; }
+
     }
 
 }


### PR DESCRIPTION
* Fixes #15
* 呼び出し順制御をしたくなることがあるので追加実装
* 各インタフェースに `UnityEditor.Build.IOrderedCallback` を継承させることで並び順制御を実現しています