### PR TITLE
AssetBundle をビルドするとき、TypeTreeHash を無視するようにする

### DIFF
--- a/Assets/Editor/Scripts/SimpleBuild/BuildAssetBundle.cs
+++ b/Assets/Editor/Scripts/SimpleBuild/BuildAssetBundle.cs
@@ -146,7 +146,7 @@ namespace SimpleBuild {
 
             preprocessors.ToList().ForEach(x => x.OnPreprocessBuildAssetBundle(this.BuildTarget, outputPath));
             AssetDatabase.Refresh();
-            BuildPipeline.BuildAssetBundles(outputPath, BuildAssetBundleOptions.ChunkBasedCompression, this.BuildTarget);
+            BuildPipeline.BuildAssetBundles(outputPath, BuildAssetBundleOptions.ChunkBasedCompression | BuildAssetBundleOptions.IgnoreTypeTreeChanges, this.BuildTarget);
             AssetDatabase.Refresh();
             postprocessors.ToList().ForEach(x => x.OnPostprocessBuildAssetBundle(this.BuildTarget, outputPath));
             AssetDatabase.Refresh();


### PR DESCRIPTION
## 🤔 背景
* スクリプトを変更しても AssetBundle の差分とみなさないようにする
    * [BuildAssetBundleOptions.IgnoreTypeTreeChanges - Unity スクリプトリファレンス](https://docs.unity3d.com/jp/current/ScriptReference/BuildAssetBundleOptions.IgnoreTypeTreeChanges.html)

## 😎 やること
* [x] `BuildPipeline.BuildAssetBundles` に `BuildAssetBundleOptions.IgnoreTypeTreeChanges` のパラメータを追加する